### PR TITLE
Hex web undo fix

### DIFF
--- a/web/hex/static/js/main.js
+++ b/web/hex/static/js/main.js
@@ -198,6 +198,7 @@ function draw_piece(hexagon, piece, graphics) {
 }
 
 function draw_play_area(hexagons, graphics) {
+    graphics.clear();
     graphics.lineStyle(2, 0x000000, 1);
 
     for (var i = 0; i < hexagons.length; ++i) {
@@ -209,6 +210,7 @@ function draw_play_area(hexagons, graphics) {
 }
 
 function draw_border(hexagons, graphics) {
+    graphics.clear();
     graphics.lineStyle(2, 0x000000, 1);
 
     for (var i = 0; i < hexagons.length; ++i) {


### PR DESCRIPTION
Fixes #50 

This patch splits the graphics objects for the border and play area, and then ensures the graphics are cleared before drawing the relevant part of the board.

The root cause of the issue was that when an undo happened, the relevant part of the board was not cleared. Therefore, pieces would visually remain on the board even when they did not exist as part of the game state.
