### PR TITLE
GIT: Add hex web dependencies to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ tmp
 
 # Virtual Environment
 venv
+
+# Web dependencies
+web/hex/static/deps


### PR DESCRIPTION
This patch adds hex web dependencies to the files git will ignore. Installing dependencies with bower will no longer cause untracked files to appear in the working tree.
