### PR TITLE
Test coverage tool, resolving #71

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -9,6 +9,10 @@ default: install
 test: setup.py
 	$(PYTHON) setup.py -q test --addopts '-x $(ARGS)'
 
+.PHONY: test-cov
+test-cov: ARGS=--cov games_puzzles_algorithms --cov-report term:skip-covered
+test-cov: test
+
 .PHONY: install
 install: requirements.txt
 	$(PIP) install -r requirements.txt $(ARGS)

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -12,6 +12,6 @@ setup(
         'future == 0.15.2',
         'setuptools == 20.2.2'
     ],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'pytest-cov'],
     setup_requires=['pytest-runner']
 )


### PR DESCRIPTION
Run `make test-cov` to show coverage. Fully covered files will
not be shown (so that __init__.py is ignored).