### PR TITLE
Fix reference before assignment in cli.

### DIFF
--- a/lib/games_puzzles_algorithms/games/cli.py
+++ b/lib/games_puzzles_algorithms/games/cli.py
@@ -162,7 +162,7 @@ class Cli(Cmd, object):
         try:
             size = int(args)
         except ValueError:
-            return (False, "Argument \"{}\" is not a valid size".format(size))
+            return (False, "Argument \"{}\" is not a valid size".format(args))
         if size < 1:
             return (False, "Argument \"{}\" is not a valid size".format(size))
         self.game.reset(size)


### PR DESCRIPTION
Fixes a small bug where we try to print an unset variable when handling an exception parsing that variable.