### PR TITLE
Hex reset

### DIFF
--- a/lib/bin/gpa-games-cli
+++ b/lib/bin/gpa-games-cli
@@ -67,7 +67,7 @@ class HexCliGameState(UiGameState):
             raise("Unrecognized player, \"{}\"".format(ui_player))
 
     def reset_state(self):
-        self.state.reset(*self.state.board.size())
+        self.state.reset()
         return self
 
 

--- a/lib/bin/gpa-games-cli
+++ b/lib/bin/gpa-games-cli
@@ -68,7 +68,6 @@ class HexCliGameState(UiGameState):
 
     def reset_state(self):
         self.state.reset()
-        return self
 
 
 class TttCliGameState(UiGameState):
@@ -94,7 +93,6 @@ class TttCliGameState(UiGameState):
 
     def reset_state(self):
         self.state.reset()
-        return self
 
 
 GAMES = {'hex': HexCliGameState, 'ttt': TttCliGameState}

--- a/lib/games_puzzles_algorithms/games/hex/game_state.py
+++ b/lib/games_puzzles_algorithms/games/hex/game_state.py
@@ -201,6 +201,13 @@ class GameState(object):
             WinDetector.root(NUM_PLAYERS)
         )
 
+    def reset(self):
+        """Reset the board."""
+        player = color_to_player(COLORS["white"])
+        board = self.clean_board(*self.board.size())
+        win_detector = WinDetector.root(NUM_PLAYERS)
+        self.__init__(player, board, self.win_detector)
+
     def __init__(self, acting_player, board, win_detector):
         self._acting_player = acting_player
         self._previous_acting_players = []


### PR DESCRIPTION
The games cli expects a reset_state() method to be available which mutates the game state to an initial state. This method is implemented by calling reset() on each game's game state.

Previously, the hex game state had no reset() method, even though one was being called.

This change adds reset() to the hex game state, and removes unnecessary returns from the reset_state() methods for hex and ttt.