### PR TITLE
Gtp tournament

### DIFF
--- a/lib/games_puzzles_algorithms/games/cli.py
+++ b/lib/games_puzzles_algorithms/games/cli.py
@@ -262,10 +262,16 @@ class Cli(Cmd, object):
 
     def do_winner(self, args, opts=None):
         """Return the winner of the current game."""
-        for player in range(2):
-            if self.game.state.score(player) > 0:
-                return (True, self.game.player_to_ui_player(player))
-        return (True, None)
+        scores = [(self.game.state.score(p), p) for p in range(2)]
+
+        if any(s is None for (s, _) in scores):
+            return (True, "") # Game is not over yet.
+
+        (score, winner) = max(scores)
+
+        if score == 0:
+            return (True, "0")
+        return (True, self.game.player_to_ui_player(winner))
 
     def do_analyze(self, arg, opts=None):
         """Added to avoid crashing with GTP tools but not yet implemented."""

--- a/lib/games_puzzles_algorithms/games/cli.py
+++ b/lib/games_puzzles_algorithms/games/cli.py
@@ -271,7 +271,8 @@ class Cli(Cmd, object):
 
         if score == 0:
             return (True, "0")
-        return (True, self.game.player_to_ui_player(winner))
+        return (True, "{}+{}".format(self.game.player_to_ui_player(winner),
+                                     score))
 
     def do_analyze(self, arg, opts=None):
         """Added to avoid crashing with GTP tools but not yet implemented."""

--- a/tournament/play_tournament.py
+++ b/tournament/play_tournament.py
@@ -1,0 +1,68 @@
+import argparse
+import logging
+import sys
+
+from player import Player
+from tournament import Tournament
+
+
+def tournament_args():
+    parser = argparse.ArgumentParser('Play a tournament between two GTP '
+                                     'players.')
+    parser.add_argument('players', nargs=2,
+                        help='Invocation for each GTP player.')
+    parser.add_argument('-n', '--num-games', type=int, default=1,
+                        help='Number of games in tournament.')
+    parser.add_argument('-s', '--size', type=int, default=3,
+                        help='Size of game instance.')
+    parser.add_argument('-t', '--time-limit', type=int, default=1,
+                        help='Time limit for each move, in seconds.')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Use verbose output for stdout.')
+    parser.add_argument('-l', '--log-file', help='File to store logs.')
+    return parser.parse_args()
+
+
+def tournament_logger(verbose=False, log_file=None):
+    """Creates and configures a logger for use with the tournament."""
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(message)s\n')
+
+    if log_file is not None:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(formatter)
+
+    if verbose:
+        stdout_handler.setLevel(logging.DEBUG)
+    else:
+        stdout_handler.setLevel(logging.INFO)
+
+    logger.addHandler(stdout_handler)
+
+    return logger
+
+
+def main():
+    args = tournament_args()
+
+    logger = tournament_logger(verbose=args.verbose, log_file=args.log_file)
+
+    players = [Player(invocation) for invocation in args.players]
+
+    tournament = Tournament(players, args.num_games, args.size,
+                            args.time_limit, logger)
+
+    tournament.play_tournament()
+
+    for p in players:
+        p.exit()
+
+
+if __name__ == '__main__':
+    main()

--- a/tournament/player.py
+++ b/tournament/player.py
@@ -1,0 +1,130 @@
+import re
+import shlex
+
+from subprocess import PIPE, Popen, TimeoutExpired
+
+
+class PlayerException(Exception):
+    pass
+
+
+class PlayerCmdException(PlayerException):
+    pass
+
+
+class Player(object):
+    """
+    Player is a simple interface to a game playing process which is communicated
+    with using the GTP protocol. Player contains very minimal logic outside of
+    nicely handling interaction with the player process.
+    """
+    def __init__(self, invocation):
+        args = shlex.split(invocation)
+        self._process = Popen(args, stdin=PIPE, stdout=PIPE,
+                              universal_newlines=True)
+        self._stdout = self._process.stdout
+        self._stdin = self._process.stdin
+
+    def _write(self, command):
+        self._stdin.write(command)
+        self._stdin.write('\n')
+        self._stdin.flush()
+
+    def _read(self):
+        response = self._stdout.readline()
+
+        next_line = self._stdout.readline()
+
+        while next_line != '\n':
+            response += next_line
+            next_line = self._stdout.readline()
+
+        return response
+
+    def _cmd(self, command):
+        self._write(command)
+
+        response = self._read()
+        error_occurred = response.startswith('?')
+        response = response[2:].rstrip()
+
+        if error_occurred:
+            raise PlayerCmdException("Error issuing command: '{}'. Response "
+                                     "was: '{}'".format(command, response))
+        return response
+
+    def exit(self):
+        self._cmd('q')
+        try:
+            rc = self._process.wait(timeout=10)
+            if rc != 0:
+                raise PlayerException('{} exited with non-zero error code {}'
+                                      .format(self._process.pid, rc))
+        except TimeoutExpired:
+            raise PlayerException('Timed out wating for {} to exit.'
+                                  .format(self._process.pid))
+
+    def _set_size(self, size):
+        self._cmd('size {}'.format(size))
+
+    def _set_time_limit(self, time_limit):
+        self._cmd('set_time {}'.format(time_limit))
+
+    def _gen_move(self):
+        return self._cmd('genmove')
+
+    def _play_move(self, move):
+        self._cmd('play {}'.format(move))
+
+    def _name(self):
+        return self._cmd('name')
+
+    def _clear_board(self):
+        self._cmd('clear_board')
+
+    def _winner(self):
+        return self._cmd('winner')
+
+    def _board(self):
+        return self._cmd('showboard')
+
+    def configure(self, size=None, time_limit=None):
+        if size is not None:
+            self._set_size(size)
+        if time_limit is not None:
+            self._set_time_limit(time_limit)
+
+    def play(self, move=None):
+        if move is not None:
+            self._play_move(move)
+            return
+        return self._gen_move()
+
+    def clear(self):
+        self._clear_board()
+
+    def game_finished(self):
+        # An empty string indicates the game is ongoing.
+        win_string = self._winner()
+        return bool(win_string)
+
+    def winner(self):
+        win_string = self._winner()
+
+        if win_string == '0':
+            return ('0', '0')
+
+        regex = r'(?P<winner>.*)\+(?P<score>.*)'
+        result = re.match(regex, win_string)
+
+        if result is None:
+            raise PlayerException('Could not parse win string: '
+                                  '{}'.format(win_string))
+
+        return (result.group('winner'), result.group('score'))
+
+    def board(self):
+        return self._board()
+
+    def __str__(self):
+        return '{}-{}'.format(self._name(), self._process.pid)

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -1,0 +1,125 @@
+from collections import defaultdict
+
+
+class TournamentResult(object):
+    """
+    TournamentResult holds the result of a tournament. This is defined as a
+    count of how many times each player has won, the count of how many draws
+    have occurred, and the sequence of wins as they occurred.
+    """
+    def __init__(self):
+        self._sequence = []
+        self._results = defaultdict(int)
+        self._draws = 0
+
+    def increment_win_count(self, player, side):
+        # Check for a draw.
+        if side == '0':
+            self._sequence.append(('Draw', '0'))
+            self._draws += 1
+        else:
+            self._sequence.append((player, side))
+            self._results[player] += 1
+
+    def __str__(self):
+        outcomes = []
+
+        for (player, games) in self._results.items():
+            outcomes.append('{} won {} games.'.format(player, games))
+
+        if self._draws > 0:
+            outcomes.append('{} draws occurred.'.format(self._draws))
+
+        return '\n'.join(outcomes)
+
+
+class Tournament(object):
+    """
+    Tournament is used to run a tournament between two GTP players. The
+    tournament will handle configuring the players as necessary, and will then
+    play a series of rounds between the players. The first player to play
+    alternates between players each round. A round consists of both players
+    making moves until they agree that the game is over. We make the assumption
+    that players will agree the game is over after a winning move has been made.
+    """
+    def __init__(self, players, num_games, game_size, time_limit, logger):
+        self._logger = logger
+        self._results = TournamentResult()
+        self._round = 1
+        self._players = players
+        self._games = num_games
+        self._size = game_size
+        self._time_limit = time_limit
+        self._configure_players()
+
+    def _configure_players(self):
+        """Send configuration to each player"""
+        for player in self._players:
+            player.configure(size=self._size, time_limit=self._time_limit)
+
+    def _round_finished(self):
+        """Ask if players agree the game is finished."""
+        return all(p.game_finished() for p in self._players)
+
+    def _notify_players(self, move, skip_index):
+        """
+        Notify all other players of the given move, skipping the player at
+        index.
+        """
+        for (i, player) in enumerate(self._players):
+            if i == skip_index:
+                continue
+            player.play(move)
+
+    def _next_player(self, player_index):
+        """Return the next to play after the player at the given index."""
+        num_players = len(self._players)
+        return (player_index + 1) % num_players
+
+    def _play_round(self, first_to_play):
+        """Play a single round of a tournament."""
+        for player in self._players:
+            player.clear()
+
+        player_index = first_to_play
+
+        while not self._round_finished():
+            player = self._players[player_index]
+            move = player.play()
+
+            self._logger.debug('{} plays {}\n{}'.format(player, move,
+                                                        player.board()))
+
+            self._notify_players(move, player_index)
+            player_index = self._next_player(player_index)
+
+        (winner, _) = player.winner()
+
+        # We currently make the assumption that wins are detected immediately
+        # by both players, and thus the last player to act is the winner if a
+        # draw has not occurred.
+        self._results.increment_win_count(str(player), winner)
+        self._logger.debug('{} wins round {} as {}'.format(player, self._round,
+                                                           winner))
+
+        self._round += 1
+
+    def play_tournament(self):
+        """Play a full tournament between the players."""
+        self._logger.info(self)
+        self._round = 1
+
+        first_to_play = 0
+        for _ in range(self._games):
+            self._play_round(first_to_play)
+            first_to_play = self._next_player(first_to_play)
+
+        self._logger.info(self._results)
+
+    def __str__(self):
+        players = ' vs. '.join(str(p) for p in self._players)
+        size = 'Size: {}'.format(self._size)
+        time = 'Time limit: {}s'.format(self._time_limit)
+        games = 'Games: {}'.format(self._games)
+
+        return '\n'.join((players, size, time, games))


### PR DESCRIPTION
This change set does the following:

* Slightly modifies the logic of the 'winner' cli command. (See below)
* Modifies the 'winner' cli command output to include a score.
* Adds basic GTP tournament support.

The 'winner' cli command had a couple of bugs previously. Firstly, the default returned None, which would immediately raise an exception on return since None cannot be implicitly converted to a string. Secondly, if the game was ongoing, the game states would return None for the player score, which would raise an exception when None was compared to 0. Finally, we were not handling draws, as we only checked for if one of the players had won, and in the case of both players' scores being 0 (a draw), we would return None.

Returning '0' for the winner of a draw is in line with MichiGo's scoring, which simply returns '0' instead of 'B+x' or 'W+y' in the case of both players having the same score and the game ending in a draw.