### PR TITLE
Fix Tic-tac-toe Win Detection

### DIFF
--- a/lib/games_puzzles_algorithms/games/ttt/game_state.py
+++ b/lib/games_puzzles_algorithms/games/ttt/game_state.py
@@ -1,6 +1,7 @@
 from array import array
 from enum import IntEnum
 from string import ascii_uppercase as alphabet
+from copy import deepcopy
 
 
 class BoardValues(IntEnum):
@@ -75,10 +76,16 @@ class TwoDimensionalTable(object):
 class Board(object):
 
     def __init__(self, num_rows=3, num_columns=None, num_spaces_to_win=None):
+        num_rows = max(num_rows, 1)
         if num_columns is None:
             num_columns = num_rows
-        if num_spaces_to_win is None:
-            num_spaces_to_win = min(num_rows, num_columns)
+        else:
+            num_columns = max(num_columns, 1)
+        # TODO Cannot support arbitrary num_spaces_to_win
+        # if num_spaces_to_win is None:
+        num_spaces_to_win = min(num_rows, num_columns)
+        # else:
+        #     num_spaces_to_win = max(min(max(num_rows, num_columns), num_spaces_to_win), 1)
         self._num_spaces_to_win = num_spaces_to_win
         self._spaces = TwoDimensionalTable(
             num_rows,
@@ -134,7 +141,7 @@ class Board(object):
                              "player!")
         self._spaces.set_index(action, player)
         self._actions.append({'player': player, 'action': action})
-        self._update_win_status(action, player, increment=True)
+        self._update_win_status(action, player, add_symbol=True)
 
     def undo(self):
         if len(self._actions) == 0:
@@ -143,7 +150,7 @@ class Board(object):
         last_action = self._actions.pop()
         self._spaces.set_index(last_action['action'], BoardValues.Empty)
         self._update_win_status(last_action['action'],
-                                last_action['player'], increment=False)
+                                last_action['player'], add_symbol=False)
         return last_action['player']
 
     def space_is_on_positive_diagonal(self, row, column):
@@ -154,35 +161,53 @@ class Board(object):
 
     def initialize_win_status(self):
         self._status = {}
-        self._status[BoardValues.X] = {'positive_diagonal': 0,
-                                       'negative_diagonal': 0}
+        self._status[BoardValues.X] = {}
+        length_of_smallest_dimension = max(self._spaces.size())
+        for i in range(length_of_smallest_dimension - self._num_spaces_to_win + 1):
+            self._status[BoardValues.X]['positive-diagonal' + str(i)] = [False] * length_of_smallest_dimension
+            self._status[BoardValues.X]['negative-diagonal' + str(i)] = [False] * length_of_smallest_dimension
 
         for row in range(self._spaces.num_rows()):
-            self._status[BoardValues.X]['row' + str(row)] = 0
+            self._status[BoardValues.X][
+                'row' + str(row)] = [False] * self._spaces.num_columns()
 
         for column in range(self._spaces.num_columns()):
-            self._status[BoardValues.X]['column' + str(column)] = 0
+            self._status[BoardValues.X]['column' +
+                                        str(column)] = [False] * self._spaces.num_rows()
 
-        self._status[BoardValues.O] = self._status[BoardValues.X].copy()
+        self._status[BoardValues.O] = deepcopy(self._status[BoardValues.X])
 
-    def _update_win_status(self, action, player, increment=True):
+    def _update_win_status(self, action, player, add_symbol=True):
         row = self._spaces.row(action)
         column = self._spaces.column(action)
+        space = (row, column)
+        smallest_dimension = 0
+        if self._spaces.num_rows() < self._spaces.num_columns():
+            smallest_dimension = 1
 
-        modifier = 1 if increment else -1
+        modifier = True if add_symbol else False
 
-        self._status[player]['row' + str(row)] += modifier
-        self._status[player]['column' + str(column)] += modifier
+        self._status[player]['row' + str(row)][column] = modifier
+        self._status[player]['column' + str(column)][row] = modifier
 
-        if self.space_is_on_positive_diagonal(row, column):
-            self._status[player]['positive_diagonal'] += modifier
+        adjusted_space = list(space)
+        for i in range(self._spaces.size(smallest_dimension) - self._num_spaces_to_win + 1):
+            if self.space_is_on_positive_diagonal(*adjusted_space):
+                self._status[player]['positive-diagonal' + str(i)][column] = modifier
+            if self.space_is_on_negative_diagonal(*adjusted_space):
+                self._status[player]['negative-diagonal' + str(i)][column] = modifier
+            if adjusted_space[int(not(smallest_dimension))] < 1:
+                break
+            adjusted_space[int(not(smallest_dimension))] -= 1
 
-        if self.space_is_on_negative_diagonal(row, column):
-            self._status[player]['negative_diagonal'] += modifier
 
     def _has_win(self, player):
         player_status = self._status[player]
-        return any(n == self._num_spaces_to_win for n in player_status.values())
+        for line in player_status.values():
+            for initial_offset in range(len(line) - self._num_spaces_to_win + 1):
+                if all([line[initial_offset + pos] for pos in range(self._num_spaces_to_win)]):
+                    return True
+        return False
 
     def num_spaces_to_win(self): return self._num_spaces_to_win
 

--- a/lib/test/games/ttt/ttt_game_state_test.py
+++ b/lib/test/games/ttt/ttt_game_state_test.py
@@ -1,10 +1,75 @@
 from games_puzzles_algorithms.games.ttt.game_state import GameState
+from games_puzzles_algorithms.games.ttt.game_state import BoardValues
+import pytest
+
+
+@pytest.mark.skip(reason="Cannot support arbitrary num_spaces_to_win yet.")
+def test_4x6x2():
+    patient = GameState(4, 6, 2)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 5))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 1))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 3))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 2))
+    assert(patient.score(BoardValues.O) == 1)
+    assert(patient.score(BoardValues.X) == -1)
+    assert(patient.winner() == BoardValues.O)
+
+
+def test_4x6x4():
+    patient = GameState(4, 6, 4)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 5))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 1))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 4))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 2))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(2, 0))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 3))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(2, 2))
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+    patient.play(patient._spaces.index(1, 0))
+    assert(patient.score(BoardValues.O) == 1)
+    assert(patient.score(BoardValues.X) == -1)
+    assert(patient.winner() == BoardValues.O)
 
 
 def test_m_x_n_board():
     patient = GameState(2, 4)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     assert(
         str(patient) ==
         "\n" +
@@ -15,10 +80,11 @@ def test_m_x_n_board():
     )
 
 
+@pytest.mark.skip(reason="Cannot support arbitrary num_spaces_to_win yet.")
 def test_k_win():
     patient = GameState(3, num_spaces_to_win=2)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     assert(
         str(patient) ==
         "\n" +
@@ -43,16 +109,16 @@ def test_k_win():
         "  -|-|-\n" +
         "3  | | \n"
     )
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
+    assert(patient.score(BoardValues.X) == 1)
+    assert(patient.score(BoardValues.O) == -1)
     assert(patient.winner() == 0)
 
 
 def test_empty_board():
     '''Check that GameState instance is created with an empty board'''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     assert(
         str(patient) ==
         "\n" +
@@ -98,8 +164,8 @@ def test_first_player_to_move():
     Check that the player to move is X
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     assert(patient.player_to_act() == 0)
 
 
@@ -109,8 +175,8 @@ def test_moves():
     only empty spaces can be taken
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     assert(
         str(patient.play(patient._spaces.index(1, 1))) ==
         "\n" +
@@ -133,17 +199,18 @@ def test_row_win():
     Check that the match is won properly on a row
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(0, 1)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(0, 2))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
+    assert(patient.score(BoardValues.X) == 1)
+    assert(patient.score(BoardValues.O) == -1)
     assert(patient.is_terminal())
     assert(patient.num_legal_actions() == 0)
+    assert(patient.winner() == BoardValues.X)
 
 
 def test_column_win():
@@ -151,15 +218,15 @@ def test_column_win():
     Check that the match is won properly on a column
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 1)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(2, 0))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
+    assert(patient.score(BoardValues.X) == 1)
+    assert(patient.score(BoardValues.O) == -1)
     assert(patient.is_terminal())
     assert(patient.num_legal_actions() == 0)
 
@@ -170,15 +237,15 @@ def test_diag_1_win():
     (bottom left to top right)
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(1, 1)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(2, 2))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
+    assert(patient.score(BoardValues.X) == 1)
+    assert(patient.score(BoardValues.O) == -1)
     assert(patient.is_terminal())
     assert(patient.num_legal_actions() == 0)
 
@@ -188,8 +255,8 @@ def test_draw():
     Check that the match is drawn
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(0, 1)) \
@@ -200,7 +267,7 @@ def test_draw():
         .play(patient._spaces.index(2, 1)) \
         .play(patient._spaces.index(2, 2))
     assert(patient.is_terminal())
-    assert(patient.score(0) == 0)
+    assert(patient.score(BoardValues.X) == 0)
     assert(patient.is_terminal())
     assert(patient.num_legal_actions() == 0)
 
@@ -219,19 +286,19 @@ def test_winner_after_undo():
     Check that undoing a move after a win no longer results in a win.
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(1, 1)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(2, 2))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
+    assert(patient.score(BoardValues.X) == 1)
+    assert(patient.score(BoardValues.O) == -1)
     assert(patient.is_terminal())
     assert(patient.num_legal_actions() == 0)
     patient.undo()
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
     assert(not patient.is_terminal())
     assert(patient.num_legal_actions() == 5)


### PR DESCRIPTION
Note that this fix requires disabling the `num_spaces_to_win` option in the
TTT game state. Users that specify this argument will have it silently
ignored. While I'm not sure if this is the best behaviour, it
was the quickest way to resolve #87.