### PR TITLE
TTT win detection

### DIFF
--- a/lib/games_puzzles_algorithms/games/ttt/game_state.py
+++ b/lib/games_puzzles_algorithms/games/ttt/game_state.py
@@ -268,7 +268,7 @@ class Board(object):
             return self._actions[-1]['action']
 
     def play(self, action, player):
-        ''' Execute an action on the board '''
+        """ Execute an action on the board """
         if (not self._spaces.get_index(action) == BoardValues.Empty):
             raise IndexError("Cannot play in the same space as another "
                              "player!")
@@ -292,12 +292,12 @@ class Board(object):
     def num_spaces_to_win(self): return self._num_spaces_to_win
 
     def winner(self):
-        '''
+        """
         Returns: None if the game is unfinished
                  BoardValues.X if the x player has won
                  BoardValues.O if the o player has won
                  BoardValues.Empty if the game is a draw
-        '''
+        """
         if self._has_win(BoardValues.X):
             return BoardValues.X
         elif self._has_win(BoardValues.O):
@@ -356,28 +356,28 @@ class GameState(Board):
         self._next_to_act = BoardValues.X
 
     def __enter__(self):
-        '''Allows the following type of code:
+        """Allows the following type of code:
 
         ```
         with state.play(action):
             # Do something with `state` after `action`
             # has been applied to `state`.
         # `action` has automatically be undone.
-        '''
+        """
         pass
 
     def __exit__(self,
                  exception_type,
                  exception_val,
                  exception_traceback):
-        '''Allows the following type of code:
+        """Allows the following type of code:
 
         ```
         with state.play(action):
             # Do something with `state` after `action`
             # has been applied to `state`.
         # `action` has automatically be undone.
-        '''
+        """
         self.undo()
 
     def cell_index(self, row, column):

--- a/lib/games_puzzles_algorithms/games/ttt/game_state.py
+++ b/lib/games_puzzles_algorithms/games/ttt/game_state.py
@@ -79,36 +79,36 @@ class WinDetector(object):
     perform this count from left to right and top to bottom along the board.
     The value in any given cell is the length of the run ending in that cell.
     """
-    def __init__(self, rows, columns, spaces_to_win):
-        self.rows = rows
-        self.columns = columns
+    def __init__(self, num_rows, num_columns, spaces_to_win):
+        self._num_rows = num_rows
+        self._num_columns = num_columns
         self.spaces_to_win = spaces_to_win
-        self._rows = TwoDimensionalTable(rows, columns)
-        self._columns = TwoDimensionalTable(rows, columns)
-        self._diagonals = TwoDimensionalTable(rows, columns)
-        self._anti_diagonals = TwoDimensionalTable(rows, columns)
+        self._rows = TwoDimensionalTable(num_rows, num_columns)
+        self._columns = TwoDimensionalTable(num_rows, num_columns)
+        self._diagonals = TwoDimensionalTable(num_rows, num_columns)
+        self._anti_diagonals = TwoDimensionalTable(num_rows, num_columns)
 
     def _iter_row(self, row, column):
         """Iterate along a row starting at the given coordinate."""
-        for c in range(column, self.columns):
+        for c in range(column, self._num_columns):
             yield (row, c)
 
     def _iter_column(self, row, column):
         """Iterate along a column starting at the given coordinate."""
-        for r in range(row, self.rows):
+        for r in range(row, self._num_rows):
             yield (r, column)
 
     def _iter_diagonal(self, row, column):
         """Iterate along a diagonal starting at the given coordinate."""
-        row_difference = self.rows - row
-        column_difference = self.columns - column
+        row_difference = self._num_rows - row
+        column_difference = self._num_columns - column
 
         for i in range(min(row_difference, column_difference)):
             yield(row + i, column + i)
 
     def _iter_anti_diagonal(self, row, column):
         """Iterate along an anti-diagonal starting at the given coordinate."""
-        row_difference = self.rows - row
+        row_difference = self._num_rows - row
         for i in range(min(row_difference, column)):
             yield(row - i, column - i)
 
@@ -157,7 +157,7 @@ class WinDetector(object):
         Calculate the existing run-length in this anti-diagonal ending at the
         given coordinate.
         """
-        if row == 0 or column == self.columns - 1:
+        if row == 0 or column == self._num_columns - 1:
             return 0
         else:
             return self._anti_diagonals[row - 1, column + 1]

--- a/lib/games_puzzles_algorithms/games/ttt/game_state.py
+++ b/lib/games_puzzles_algorithms/games/ttt/game_state.py
@@ -77,7 +77,7 @@ class WinDetector(object):
     The WinDetector is used to track the win state of a game of tic-tac-toe.
     This is done by tracking run-lengths on the board for each direction. We
     perform this count from left to right and top to bottom along the board.
-    The value in any given cell if the length of the run ending in that cell.
+    The value in any given cell is the length of the run ending in that cell.
     """
     def __init__(self, rows, columns, spaces_to_win):
         self.rows = rows
@@ -189,14 +189,14 @@ class WinDetector(object):
             self._cascade_state_update(state, row, column, iterator)
 
     def _states(self):
-        """A generator of the WinDetector states."""
+        """A generator over the WinDetector states."""
         yield self._rows
         yield self._columns
         yield self._diagonals
         yield self._anti_diagonals
 
     def win_detected(self):
-        """Return whether any runs exist that meet the winning length."""
+        """Return whether any runs exist which meet the winning length."""
         for state in self._states():
             if any(run_length >= self.spaces_to_win for run_length in state):
                 return True

--- a/lib/games_puzzles_algorithms/games/ttt/game_state.py
+++ b/lib/games_puzzles_algorithms/games/ttt/game_state.py
@@ -110,7 +110,7 @@ class WinDetector(object):
         """Iterate along an anti-diagonal starting at the given coordinate."""
         row_difference = self._num_rows - row
         for i in range(min(row_difference, column)):
-            yield(row - i, column - i)
+            yield(row + i, column - i)
 
     def row_count(self, row):
         return sum(self._rows[r, c] > 0 for (r, c) in self._iter_row(row, 0))

--- a/lib/games_puzzles_algorithms/games/ttt/game_state.py
+++ b/lib/games_puzzles_algorithms/games/ttt/game_state.py
@@ -79,10 +79,10 @@ class WinDetector(object):
     perform this count from left to right and top to bottom along the board.
     The value in any given cell is the length of the run ending in that cell.
     """
-    def __init__(self, num_rows, num_columns, spaces_to_win):
+    def __init__(self, num_rows, num_columns, num_spaces_to_win):
         self._num_rows = num_rows
         self._num_columns = num_columns
-        self.spaces_to_win = spaces_to_win
+        self._num_spaces_to_win = num_spaces_to_win
         self._rows = TwoDimensionalTable(num_rows, num_columns)
         self._columns = TwoDimensionalTable(num_rows, num_columns)
         self._diagonals = TwoDimensionalTable(num_rows, num_columns)
@@ -197,8 +197,11 @@ class WinDetector(object):
 
     def win_detected(self):
         """Return whether any runs exist which meet the winning length."""
+        def run_is_win(run_length):
+            return run_length >= self._num_spaces_to_win
+
         for state in self._states():
-            if any(run_length >= self.spaces_to_win for run_length in state):
+            if any(run_is_win(run_length) for run_length in state):
                 return True
         return False
 

--- a/lib/test/games/ttt/ttt_game_state_test.py
+++ b/lib/test/games/ttt/ttt_game_state_test.py
@@ -84,7 +84,6 @@ def test_empty_board():
 def test_large_board_representation():
     '''Check that large boards are represented clearly.'''
     patient = GameState(10)
-    print(patient)
     assert(
         str(patient) ==
         "\n" +

--- a/lib/test/games/ttt/ttt_game_state_test.py
+++ b/lib/test/games/ttt/ttt_game_state_test.py
@@ -281,6 +281,16 @@ def test_anti_diagonal_win_k_in_a_row():
     assert_X_wins(patient)
 
 
+def test_anti_diagonal_win_k_in_a_row_downwards():
+    patient = GameState(3, 4, 2)
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 1))
+    patient.play(patient._spaces.index(0, 1))
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(0, 2))
+    assert_X_wins(patient)
+
+
 def test_heuristic():
     patient = GameState(3)
     assert patient.heuristic(0) == 0

--- a/lib/test/games/ttt/ttt_game_state_test.py
+++ b/lib/test/games/ttt/ttt_game_state_test.py
@@ -228,8 +228,59 @@ def test_winner_after_undo():
     assert_no_winner(patient)
     assert(not patient.is_terminal())
     assert(patient.num_legal_actions() == 5)
-    
-    
+
+
+def test_win_detection():
+    patient = GameState(4, 6, 2)
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 5))
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 1))
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 3))
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 2))
+    assert_O_wins(patient)
+
+
+def test_row_win_k_in_a_row():
+    patient = GameState(3, 4, 2)
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(0, 0))
+    patient.play(patient._spaces.index(1, 0))
+    patient.play(patient._spaces.index(0, 1))
+    assert_X_wins(patient)
+
+
+def test_column_win_k_in_a_row():
+    patient = GameState(3, 4, 2)
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(0, 0))
+    patient.play(patient._spaces.index(0, 1))
+    patient.play(patient._spaces.index(1, 0))
+    assert_X_wins(patient)
+
+
+def test_diagonal_win_k_in_a_row():
+    patient = GameState(3, 4, 2)
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(0, 0))
+    patient.play(patient._spaces.index(0, 1))
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 1))
+    assert_X_wins(patient)
+
+
+def test_anti_diagonal_win_k_in_a_row():
+    patient = GameState(3, 4, 2)
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(0, 2))
+    patient.play(patient._spaces.index(0, 1))
+    assert_no_winner(patient)
+    patient.play(patient._spaces.index(1, 1))
+    assert_X_wins(patient)
+
+
 def test_heuristic():
     patient = GameState(3)
     assert patient.heuristic(0) == 0

--- a/lib/test/games/ttt/ttt_game_state_test.py
+++ b/lib/test/games/ttt/ttt_game_state_test.py
@@ -1,10 +1,31 @@
-from games_puzzles_algorithms.games.ttt.game_state import GameState
+from games_puzzles_algorithms.games.ttt.game_state import BoardValues, GameState
+
+
+def assert_no_winner(patient):
+    assert(patient.score(BoardValues.X) is None)
+    assert(patient.score(BoardValues.O) is None)
+    assert(patient.winner() is None)
+
+
+def assert_X_wins(patient):
+    assert(patient.score(BoardValues.X) is 1)
+    assert(patient.score(BoardValues.O) is -1)
+    assert(patient.winner() is BoardValues.X)
+    assert(patient.is_terminal())
+    assert(patient.num_legal_actions() == 0)
+
+
+def assert_O_wins(patient):
+    assert(patient.score(BoardValues.X) is -1)
+    assert(patient.score(BoardValues.O) is 1)
+    assert(patient.winner() is BoardValues.O)
+    assert(patient.is_terminal())
+    assert(patient.num_legal_actions() == 0)
 
 
 def test_m_x_n_board():
     patient = GameState(2, 4)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     assert(
         str(patient) ==
         "\n" +
@@ -17,8 +38,7 @@ def test_m_x_n_board():
 
 def test_k_win():
     patient = GameState(3, num_spaces_to_win=2)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     assert(
         str(patient) ==
         "\n" +
@@ -43,16 +63,13 @@ def test_k_win():
         "  -|-|-\n" +
         "3  | | \n"
     )
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
-    assert(patient.winner() == 0)
+    assert_X_wins(patient)
 
 
 def test_empty_board():
     '''Check that GameState instance is created with an empty board'''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     assert(
         str(patient) ==
         "\n" +
@@ -98,9 +115,8 @@ def test_first_player_to_move():
     Check that the player to move is X
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
-    assert(patient.player_to_act() == 0)
+    assert_no_winner(patient)
+    assert(patient.player_to_act() == BoardValues.X)
 
 
 def test_moves():
@@ -109,8 +125,7 @@ def test_moves():
     only empty spaces can be taken
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     assert(
         str(patient.play(patient._spaces.index(1, 1))) ==
         "\n" +
@@ -121,7 +136,7 @@ def test_moves():
         "  -|-|-\n" +
         "3  | | \n"
     )
-    assert(patient.player_to_act() == 1)
+    assert(patient.player_to_act() == BoardValues.O)
 
     try: patient.play(patient._spaces.index(1, 1))
     except IndexError: pass
@@ -133,36 +148,26 @@ def test_row_win():
     Check that the match is won properly on a row
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(0, 1)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(0, 2))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
-    assert(patient.is_terminal())
-    assert(patient.num_legal_actions() == 0)
-
+    assert_X_wins(patient)
 
 def test_column_win():
     '''
     Check that the match is won properly on a column
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 1)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(2, 0))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
-    assert(patient.is_terminal())
-    assert(patient.num_legal_actions() == 0)
-
+    assert_X_wins(patient)
 
 def test_diag_1_win():
     '''
@@ -170,26 +175,20 @@ def test_diag_1_win():
     (bottom left to top right)
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(1, 1)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(2, 2))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
-    assert(patient.is_terminal())
-    assert(patient.num_legal_actions() == 0)
-
+    assert_X_wins(patient)
 
 def test_draw():
     '''
     Check that the match is drawn
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(0, 1)) \
@@ -200,7 +199,7 @@ def test_draw():
         .play(patient._spaces.index(2, 1)) \
         .play(patient._spaces.index(2, 2))
     assert(patient.is_terminal())
-    assert(patient.score(0) == 0)
+    assert(patient.score(BoardValues.X) == 0)
     assert(patient.is_terminal())
     assert(patient.num_legal_actions() == 0)
 
@@ -211,7 +210,7 @@ def test_empty_undo():
     '''
     patient = GameState(3)
     patient.undo()
-    assert(patient.player_to_act() == 0)
+    assert(patient.player_to_act() == BoardValues.X)
 
 
 def test_winner_after_undo():
@@ -219,20 +218,15 @@ def test_winner_after_undo():
     Check that undoing a move after a win no longer results in a win.
     '''
     patient = GameState(3)
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     patient.play(patient._spaces.index(0, 0)) \
         .play(patient._spaces.index(1, 0)) \
         .play(patient._spaces.index(1, 1)) \
         .play(patient._spaces.index(1, 2)) \
         .play(patient._spaces.index(2, 2))
-    assert(patient.score(0) == 1)
-    assert(patient.score(1) == -1)
-    assert(patient.is_terminal())
-    assert(patient.num_legal_actions() == 0)
+    assert_X_wins(patient)
     patient.undo()
-    assert(patient.score(0) is None)
-    assert(patient.score(1) is None)
+    assert_no_winner(patient)
     assert(not patient.is_terminal())
     assert(patient.num_legal_actions() == 5)
     


### PR DESCRIPTION
This change-set attempts to generalise win-detection for tic-tac-toe to work on arbitrary k-in-a-row m by n boards.

We accomplish this through a simple run-length tracking algorithm which incrementally updates the length of each run along each direction as moves are played.

Fixes #48 
Fixes #87 
