### PR TITLE
Fix boundary check error in next_state()

### DIFF
--- a/simple/life/life-asn1.py
+++ b/simple/life/life-asn1.py
@@ -121,7 +121,7 @@ def next_state(A, r, c):
                 num += 1
             if k > 0 and A[j, k-1] == ALIVE:
                 num += 1
-            if j > 0 and k < c-1 and A[j, k+1] == ALIVE:
+            if k < c-1 and A[j, k+1] == ALIVE:
                 num += 1
             if j < r-1 and k > 0 and A[j+1, k-1] == ALIVE:
                 num += 1

--- a/simple/life/life-np.py
+++ b/simple/life/life-np.py
@@ -105,7 +105,7 @@ def next_state(A, r, c):
                 num += 1
             if k > 0 and A[j, k-1] == ALIVE:
                 num += 1
-            if j > 0 and k < c-1 and A[j, k+1] == ALIVE:
+            if k < c-1 and A[j, k+1] == ALIVE:
                 num += 1
             if j < r-1 and k > 0 and A[j+1, k-1] == ALIVE:
                 num += 1


### PR DESCRIPTION
There is a bug in the stock `next_state()` function in both [life-asn1.py](../blob/master/simple/life/life-asn1.py) and [life-np.py](../blob/master/simple/life/life-np.py). Line previews are below.

https://github.com/ryanbhayward/games-puzzles-algorithms/blob/a8adf030c103e625ee4265301833c15b5af33f42/simple/life/life-asn1.py#L124

https://github.com/ryanbhayward/games-puzzles-algorithms/blob/a8adf030c103e625ee4265301833c15b5af33f42/simple/life/life-np.py#L108

Specifically, there is an unnecessary check `j > 0`, which causes the right neighbour to not to be checked when `j = 0`. In other words, whenever the current grid point being considered is on the very first row of the grid, all right neighbours are not considered, whether the point is alive or dead.

This creates weird examples such as the following:

**Input File (test):**
```
. * .
* * .
. . .
```

**Output (before fix):**
```
$ python3 life-asn1.py test
test
['.*.', '**.', '...']

.*.
**.
...

iterations 0
```

i.e. the cell in the top left is not born and thus the L-shape stays put. After the fix it behaves properly:

**Input File (test):**
```
. * .
* * .
. . .
```

**Output (after fix):**
```
$ python3 life-asn1.py test
test
['.*.', '**.', '...']

.*.
**.
...

**.
**.
...

iterations 1
```